### PR TITLE
Auto-reconnect on session expiry and cache auth tokens

### DIFF
--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -14,10 +14,18 @@ def parse_args():
 
     # Add arguments
     parser.add_argument(
-        "--allow_write", required=False, default=False, action="store_true", help="Allow write operations on the database"
+        "--allow_write",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Allow write operations on the database",
     )
-    parser.add_argument("--log_dir", required=False, default=None, help="Directory to log to")
-    parser.add_argument("--log_level", required=False, default="INFO", help="Logging level")
+    parser.add_argument(
+        "--log_dir", required=False, default=None, help="Directory to log to"
+    )
+    parser.add_argument(
+        "--log_level", required=False, default="INFO", help="Logging level"
+    )
     parser.add_argument(
         "--prefetch",
         action="store_true",
@@ -77,24 +85,27 @@ def main():
 
     # Path to the existing CA bundle used by Python
     cafile = certifi.where()
-    
+
     # Use certificate file from the repo
-    cert_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), "certs", "nscacert.pem")
-    
+    cert_file = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "certs", "nscacert.pem"
+    )
+
     custom_cafile = cafile  # Default to the existing CA bundle
     if cert_file and os.path.exists(cert_file):
         # Create a custom CA bundle that combines the default bundle with the additional certificate
         import tempfile
+
         custom_cafile = tempfile.NamedTemporaryFile(delete=False).name
-        with open(custom_cafile, 'w') as outfile:
-            with open(cafile, 'r') as infile:
+        with open(custom_cafile, "w") as outfile:
+            with open(cafile, "r") as infile:
                 outfile.write(infile.read())
-            with open(cert_file, 'r') as infile:
+            with open(cert_file, "r") as infile:
                 cert_content = infile.read()
-                if not cert_content.endswith('\n'):
-                    cert_content += '\n'
+                if not cert_content.endswith("\n"):
+                    cert_content += "\n"
                 outfile.write(cert_content)
-    
+
     default_connection_args = snowflake.connector.connection.DEFAULT_CONFIGURATION
 
     connection_args_from_env = {
@@ -106,6 +117,9 @@ def main():
     server_args, connection_args = parse_args()
 
     connection_args = {**connection_args_from_env, **connection_args}
+
+    if connection_args.get("authenticator") == "externalbrowser":
+        connection_args.setdefault("client_store_temporary_credential", True)
 
     assert (
         "database" in connection_args

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -120,9 +120,6 @@ def main():
 
     if connection_args.get("authenticator") == "externalbrowser":
         connection_args.setdefault("client_store_temporary_credential", True)
-        os.environ.setdefault(
-            "SF_CLIENT_STORE_TEMPORARY_CREDENTIAL", "true"
-        )
 
     assert (
         "database" in connection_args

--- a/src/mcp_snowflake_server/__init__.py
+++ b/src/mcp_snowflake_server/__init__.py
@@ -120,6 +120,9 @@ def main():
 
     if connection_args.get("authenticator") == "externalbrowser":
         connection_args.setdefault("client_store_temporary_credential", True)
+        os.environ.setdefault(
+            "SF_CLIENT_STORE_TEMPORARY_CREDENTIAL", "true"
+        )
 
     assert (
         "database" in connection_args

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from typing import Any
 
+import snowflake.connector
 from snowflake.snowpark import Session
 from snowflake.snowpark.exceptions import SnowparkSessionException
 
@@ -25,10 +26,11 @@ class SnowflakeDB:
     async def _init_database(self):
         """Initialize connection to the Snowflake database"""
         try:
-            # Create session without setting specific database and schema
-            self.session = Session.builder.configs(self.connection_config).create()
+            conn = snowflake.connector.connect(**self.connection_config)
+            self.session = Session.builder.configs(
+                {"connection": conn}
+            ).create()
 
-            # Set initial warehouse if provided, but don't set database or schema
             if "warehouse" in self.connection_config:
                 self.session.sql(
                     f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -1,10 +1,10 @@
 import asyncio
 import logging
-import time
 import uuid
 from typing import Any
 
 from snowflake.snowpark import Session
+from snowflake.snowpark.exceptions import SnowparkSessionException
 
 # Configure logging
 logging.basicConfig(
@@ -16,13 +16,10 @@ logger = logging.getLogger("mcp_snowflake_server")
 
 
 class SnowflakeDB:
-    AUTH_EXPIRATION_TIME = 1800
-
     def __init__(self, connection_config: dict):
         self.connection_config = connection_config
         self.session = None
         self.insights: list[str] = []
-        self.auth_time = 0
         self.init_task = None  # To store the task reference
 
     async def _init_database(self):
@@ -33,9 +30,9 @@ class SnowflakeDB:
 
             # Set initial warehouse if provided, but don't set database or schema
             if "warehouse" in self.connection_config:
-                self.session.sql(f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}")
-
-            self.auth_time = time.time()
+                self.session.sql(
+                    f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"
+                )
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")
 
@@ -46,14 +43,16 @@ class SnowflakeDB:
         self.init_task = loop.create_task(self._init_database())
         return self.init_task
 
-    async def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
-        """Execute a SQL query and return results as a list of dictionaries"""
-        # If init_task exists and isn't done, wait for it to complete
+    async def _ensure_session(self):
+        """Ensure we have a valid session, waiting for init or creating one as needed."""
         if self.init_task and not self.init_task.done():
             await self.init_task
-        # If session doesn't exist or has expired, initialize it and wait
-        elif not self.session or time.time() - self.auth_time > self.AUTH_EXPIRATION_TIME:
+        elif not self.session:
             await self._init_database()
+
+    async def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
+        """Execute a SQL query and return results as a list of dictionaries"""
+        await self._ensure_session()
 
         logger.debug(f"Executing query: {query}")
         try:
@@ -61,6 +60,15 @@ class SnowflakeDB:
             result_rows = result.to_dict(orient="records")
             data_id = str(uuid.uuid4())
 
+            return result_rows, data_id
+
+        except SnowparkSessionException:
+            logger.warning("Session expired, re-authenticating...")
+            self.session = None
+            await self._init_database()
+            result = self.session.sql(query).to_pandas()
+            result_rows = result.to_dict(orient="records")
+            data_id = str(uuid.uuid4())
             return result_rows, data_id
 
         except Exception as e:

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -32,7 +32,7 @@ class SnowflakeDB:
             if "warehouse" in self.connection_config:
                 self.session.sql(
                     f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"
-                )
+                ).collect()
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")
 
@@ -45,10 +45,19 @@ class SnowflakeDB:
 
     async def _ensure_session(self):
         """Ensure we have a valid session, waiting for init or creating one as needed."""
-        if self.init_task and not self.init_task.done():
-            await self.init_task
-        elif not self.session:
+        if self.init_task:
+            if not self.init_task.done():
+                await self.init_task
+            else:
+                self.init_task.result()
+        if not self.session:
             await self._init_database()
+
+    def _run_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
+        result = self.session.sql(query).to_pandas()
+        result_rows = result.to_dict(orient="records")
+        data_id = str(uuid.uuid4())
+        return result_rows, data_id
 
     async def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
         """Execute a SQL query and return results as a list of dictionaries"""
@@ -56,20 +65,13 @@ class SnowflakeDB:
 
         logger.debug(f"Executing query: {query}")
         try:
-            result = self.session.sql(query).to_pandas()
-            result_rows = result.to_dict(orient="records")
-            data_id = str(uuid.uuid4())
-
-            return result_rows, data_id
+            return self._run_query(query)
 
         except SnowparkSessionException:
             logger.warning("Session expired, re-authenticating...")
             self.session = None
             await self._init_database()
-            result = self.session.sql(query).to_pandas()
-            result_rows = result.to_dict(orient="records")
-            data_id = str(uuid.uuid4())
-            return result_rows, data_id
+            return self._run_query(query)
 
         except Exception as e:
             logger.error(f'Database error executing "{query}": {e}')


### PR DESCRIPTION
## Summary

[GROWTH-1150](https://deliveroo.atlassian.net/browse/GROWTH-1150)

- **Remove hardcoded auth expiration** -- the previous `AUTH_EXPIRATION_TIME` (30 min) forced a re-auth on a fixed timer regardless of whether the session was still valid. Removed this so sessions persist as long as Snowflake allows.
- **Auto-reconnect on session expiry** -- instead of a timer, the MCP server now catches `SnowparkSessionException` when the session actually expires and re-authenticates automatically, then retries the query.
- **Cache externalbrowser auth tokens** -- enables `client_store_temporary_credential` for `externalbrowser` auth so the ID token is cached to `~/.cache/snowflake/credential_cache_v1.json`. Multiple Cursor instances share the cached token, so only the first one triggers a browser login window.

## Changes

- `src/mcp_snowflake_server/db_client.py` -- remove `AUTH_EXPIRATION_TIME` and `auth_time` tracking, extract `_ensure_session()` and `_run_query()`, add `SnowparkSessionException` retry in `execute_query()`, add `.collect()` to `USE WAREHOUSE`
- `src/mcp_snowflake_server/__init__.py` -- set `client_store_temporary_credential=True` and `SF_CLIENT_STORE_TEMPORARY_CREDENTIAL` env var when authenticator is `externalbrowser`

## Prerequisites

Token caching requires `ALLOW_ID_TOKEN = TRUE` on the Snowflake account (server-side setting, typically already enabled for externalbrowser auth). If not enabled, the MCP still works normally -- sessions just won't be cached across instances.

## Test plan

- [ ] Verify MCP connects normally on first use (browser window opens, auth succeeds)
- [ ] Verify subsequent MCP instances in other Cursor windows do not open a browser
- [ ] Verify that after a session timeout, the next query auto-reconnects instead of failing
- [ ] Verify sessions persist longer than the previous 30-minute expiration

[GROWTH-1150]: https://deliveroo.atlassian.net/browse/GROWTH-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ