### PR TITLE
Remove fixed auth timeout and auto-reconnect on session expiry

### DIFF
--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -32,9 +32,9 @@ class SnowflakeDB:
             if "warehouse" in self.connection_config:
                 self.session.sql(
                     f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"
-                )
+                ).collect()
         except Exception as e:
-            raise ValueError(f"Failed to connect to Snowflake database: {e}")
+            raise ValueError(f"Failed to connect to Snowflake database: {e}") from e
 
     def start_init_connection(self):
         """Start database initialization in the background"""
@@ -64,6 +64,10 @@ class SnowflakeDB:
             # Session has expired (e.g. token timeout after inactivity).
             # Re-authenticate and retry rather than surfacing the error.
             logger.warning("Session expired, re-authenticating...")
+            try:
+                self.session.close()
+            except Exception:
+                pass
             self.session = None
             await self._init_database()
             result = self.session.sql(query).to_pandas()

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -1,10 +1,10 @@
 import asyncio
 import logging
-import time
 import uuid
 from typing import Any
 
 from snowflake.snowpark import Session
+from snowflake.snowpark.exceptions import SnowparkSessionException
 
 # Configure logging
 logging.basicConfig(
@@ -16,13 +16,10 @@ logger = logging.getLogger("mcp_snowflake_server")
 
 
 class SnowflakeDB:
-    AUTH_EXPIRATION_TIME = 1800
-
     def __init__(self, connection_config: dict):
         self.connection_config = connection_config
         self.session = None
         self.insights: list[str] = []
-        self.auth_time = 0
         self.init_task = None  # To store the task reference
 
     async def _init_database(self):
@@ -32,10 +29,12 @@ class SnowflakeDB:
             self.session = Session.builder.configs(self.connection_config).create()
 
             # Set initial warehouse if provided, but don't set database or schema
+            # .collect() is required because Session.sql() returns a lazy
+            # DataFrame that won't execute until an action is triggered
             if "warehouse" in self.connection_config:
-                self.session.sql(f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}")
-
-            self.auth_time = time.time()
+                self.session.sql(
+                    f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"
+                ).collect()
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")
 
@@ -46,22 +45,39 @@ class SnowflakeDB:
         self.init_task = loop.create_task(self._init_database())
         return self.init_task
 
+    async def _ensure_session(self):
+        """Ensure we have a valid session, waiting for init or creating one as needed."""
+        if self.init_task:
+            if not self.init_task.done():
+                await self.init_task
+            else:
+                # Re-raise any exception from the background init so failures
+                # aren't silently swallowed
+                self.init_task.result()
+        if not self.session:
+            await self._init_database()
+
+    def _run_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
+        result = self.session.sql(query).to_pandas()
+        result_rows = result.to_dict(orient="records")
+        data_id = str(uuid.uuid4())
+        return result_rows, data_id
+
     async def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
         """Execute a SQL query and return results as a list of dictionaries"""
-        # If init_task exists and isn't done, wait for it to complete
-        if self.init_task and not self.init_task.done():
-            await self.init_task
-        # If session doesn't exist or has expired, initialize it and wait
-        elif not self.session or time.time() - self.auth_time > self.AUTH_EXPIRATION_TIME:
-            await self._init_database()
+        await self._ensure_session()
 
         logger.debug(f"Executing query: {query}")
         try:
-            result = self.session.sql(query).to_pandas()
-            result_rows = result.to_dict(orient="records")
-            data_id = str(uuid.uuid4())
+            return self._run_query(query)
 
-            return result_rows, data_id
+        except SnowparkSessionException:
+            # Session has expired (e.g. token timeout after inactivity).
+            # Re-authenticate and retry rather than surfacing the error.
+            logger.warning("Session expired, re-authenticating...")
+            self.session = None
+            await self._init_database()
+            return self._run_query(query)
 
         except Exception as e:
             logger.error(f'Database error executing "{query}": {e}')

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any
 
 from snowflake.snowpark import Session
+from snowflake.snowpark.exceptions import SnowparkSessionException
 
 # Configure logging
 logging.basicConfig(
@@ -47,7 +48,7 @@ class SnowflakeDB:
         # If init_task exists and isn't done, wait for it to complete
         if self.init_task and not self.init_task.done():
             await self.init_task
-        # If session doesn't exist or has expired, initialize it and wait
+        # If session was never created, initialize it
         elif not self.session:
             await self._init_database()
 
@@ -57,6 +58,17 @@ class SnowflakeDB:
             result_rows = result.to_dict(orient="records")
             data_id = str(uuid.uuid4())
 
+            return result_rows, data_id
+
+        except SnowparkSessionException:
+            # Session has expired (e.g. token timeout after inactivity).
+            # Re-authenticate and retry rather than surfacing the error.
+            logger.warning("Session expired, re-authenticating...")
+            self.session = None
+            await self._init_database()
+            result = self.session.sql(query).to_pandas()
+            result_rows = result.to_dict(orient="records")
+            data_id = str(uuid.uuid4())
             return result_rows, data_id
 
         except Exception as e:

--- a/src/mcp_snowflake_server/db_client.py
+++ b/src/mcp_snowflake_server/db_client.py
@@ -4,7 +4,6 @@ import uuid
 from typing import Any
 
 from snowflake.snowpark import Session
-from snowflake.snowpark.exceptions import SnowparkSessionException
 
 # Configure logging
 logging.basicConfig(
@@ -29,12 +28,10 @@ class SnowflakeDB:
             self.session = Session.builder.configs(self.connection_config).create()
 
             # Set initial warehouse if provided, but don't set database or schema
-            # .collect() is required because Session.sql() returns a lazy
-            # DataFrame that won't execute until an action is triggered
             if "warehouse" in self.connection_config:
                 self.session.sql(
                     f"USE WAREHOUSE {self.connection_config['warehouse'].upper()}"
-                ).collect()
+                )
         except Exception as e:
             raise ValueError(f"Failed to connect to Snowflake database: {e}")
 
@@ -45,39 +42,22 @@ class SnowflakeDB:
         self.init_task = loop.create_task(self._init_database())
         return self.init_task
 
-    async def _ensure_session(self):
-        """Ensure we have a valid session, waiting for init or creating one as needed."""
-        if self.init_task:
-            if not self.init_task.done():
-                await self.init_task
-            else:
-                # Re-raise any exception from the background init so failures
-                # aren't silently swallowed
-                self.init_task.result()
-        if not self.session:
-            await self._init_database()
-
-    def _run_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
-        result = self.session.sql(query).to_pandas()
-        result_rows = result.to_dict(orient="records")
-        data_id = str(uuid.uuid4())
-        return result_rows, data_id
-
     async def execute_query(self, query: str) -> tuple[list[dict[str, Any]], str]:
         """Execute a SQL query and return results as a list of dictionaries"""
-        await self._ensure_session()
+        # If init_task exists and isn't done, wait for it to complete
+        if self.init_task and not self.init_task.done():
+            await self.init_task
+        # If session doesn't exist or has expired, initialize it and wait
+        elif not self.session:
+            await self._init_database()
 
         logger.debug(f"Executing query: {query}")
         try:
-            return self._run_query(query)
+            result = self.session.sql(query).to_pandas()
+            result_rows = result.to_dict(orient="records")
+            data_id = str(uuid.uuid4())
 
-        except SnowparkSessionException:
-            # Session has expired (e.g. token timeout after inactivity).
-            # Re-authenticate and retry rather than surfacing the error.
-            logger.warning("Session expired, re-authenticating...")
-            self.session = None
-            await self._init_database()
-            return self._run_query(query)
+            return result_rows, data_id
 
         except Exception as e:
             logger.error(f'Database error executing "{query}": {e}')


### PR DESCRIPTION
## Summary

[GROWTH-1150](https://deliveroo.atlassian.net/browse/GROWTH-1150)

The MCP server previously forced re-authentication every 30 minutes via a hardcoded `AUTH_EXPIRATION_TIME` timer, regardless of whether the Snowflake session was still valid. This caused unnecessary browser auth popups during active use. When the session did genuinely expire, the server would just error.

This PR removes the fixed timer so sessions persist as long as Snowflake allows, and adds automatic re-authentication when the session actually expires.

## Changes

In `src/mcp_snowflake_server/db_client.py`:

- **Remove `AUTH_EXPIRATION_TIME` constant and `auth_time` tracking** -- no more 30-minute forced re-auth cycle
- **Auto-reconnect on real session expiry** -- catch `SnowparkSessionException` when a query fails due to an expired session, re-authenticate, and retry the query automatically

## Test plan

- [x] Verify MCP connects and queries work normally
- [x] Verify sessions persist beyond the previous 30-minute limit
- [x] Verify that after a genuine session timeout, the next query auto-reconnects instead of failing

[GROWTH-1150]: https://deliveroo.atlassian.net/browse/GROWTH-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ